### PR TITLE
playWriter 적용

### DIFF
--- a/src/main/java/com/trendyTracker/common/config/InterCeptorConfig.java
+++ b/src/main/java/com/trendyTracker/common/config/InterCeptorConfig.java
@@ -1,0 +1,24 @@
+package com.trendyTracker.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class InterCeptorConfig implements WebMvcConfigurer{
+    @Value("${token.value}")
+    private String tokenValue;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry){
+        // JWT 토큰 검증을 적용할 URL 패턴 지정
+        registry.addInterceptor(new JwtInterceptor(tokenValue))
+            // Tech
+            .addPathPatterns("/api/tech/stack/create")
+            .addPathPatterns("/api/tech/stack/delete")
+            // Recruit
+            .addPathPatterns("/api/recruit/regist");         
+
+    }
+}

--- a/src/main/java/com/trendyTracker/common/config/JwtInterceptor.java
+++ b/src/main/java/com/trendyTracker/common/config/JwtInterceptor.java
@@ -1,0 +1,34 @@
+package com.trendyTracker.common.config;
+
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class JwtInterceptor implements HandlerInterceptor {
+    private String adminToken;
+
+    public JwtInterceptor(String adminToken){
+        this.adminToken = adminToken;
+    }
+    
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler){
+
+        // JWT 토큰 검증 로직 구현
+        String token = request.getHeader("Authorization");
+        if (token != null && token.startsWith("Bearer ")) {
+            String jwtToken = token.substring(7);
+
+            // Admin 토큰
+            if (jwtToken.equals(adminToken)) return true;
+
+            return false;
+        }
+        else {
+            // JWT 토큰이 없는 경우 처리
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
기존 TrendyTracker 의 웹스크래핑으로 Selenium 을 사용했었는데 몇가지 이슈가 있었습니다.

> selenium 은 기본적으로 chrome 드라이버가 실행하는 서버가 설치되어야 하고, 설치된 chrome 과 버전이 일치해야한다.

> arm64 아키턱처 aarch64 의 RaspberryPi4 에서는 대중적이지 않는 드라이버 버전을 사용하고 있고 자체 서버에서는 돌아가지만 docker 컨테이너 안에서도 해당 버전의 드라이버 설치를 하는게 어렵다.

해당 이슈로 드라이버에 종속적이지 않은 playWrite 를 활용해 웹 스크래핑을 진행합니다. 

