### PR TITLE
OS 별 셀레니움 드라이버 실행구조 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM  gradle:jdk17 AS builder
 
 # 소스 코드를 현재 디렉토리로 복사합니다.
 COPY --chown=gradle:gradle . /app
-# COPY gradlew /app/gradlew
 
 # 작업 디렉터리 생성
 WORKDIR /app

--- a/src/main/java/com/trendyTracker/util/UrlReader.java
+++ b/src/main/java/com/trendyTracker/util/UrlReader.java
@@ -1,5 +1,6 @@
 package com.trendyTracker.util;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -16,15 +17,8 @@ import org.openqa.selenium.chrome.ChromeOptions;
 
 public class UrlReader {
     public static Set<String> getUrlContent(String url) throws IOException {
-        TechListSingleton techListSingleton = TechListSingleton.getInstance();
-        List<String> techList = techListSingleton.getTechList();
-
-        // [ MacOS ]
-        // System.setProperty("webdriver.chrome.driver", "/usr/local/bin/chromedriver");
-        // [ RaspberryPi ]
-        System.setProperty("webdriver.chrome.driver", "/usr/lib/chromium-browser/chromedriver");
-        ChromeOptions options = new ChromeOptions().addArguments("--headless");
-        WebDriver driver = new ChromeDriver(options);
+        List<String> techList = TechListSingleton.getInstance().getTechList();
+        WebDriver driver = setChromeDriver();
         
         try {
             driver.get(url);
@@ -46,8 +40,22 @@ public class UrlReader {
                 .collect(Collectors.toSet());
 
         } finally {
-            // 드라이버 종료
             driver.quit();
         }
+    }
+
+    private static WebDriver setChromeDriver() {
+        String osName = System.getProperty("os.name").toLowerCase();
+        if (osName.contains("mac")) 
+            System.setProperty("webdriver.chrome.driver", "/usr/local/bin/chromedriver");
+
+        else if (osName.contains("linux") && osName.contains("arm")) 
+            System.setProperty("webdriver.chrome.driver", "/usr/lib/chromium-browser/chromedriver");
+
+        else 
+            throw new RuntimeException("chrome driver not exist");
+        
+        ChromeOptions options = new ChromeOptions().addArguments("--headless");
+        return new ChromeDriver(options);
     }
 }

--- a/src/test/java/com/trendyTracker/util/UrlReaderTest.java
+++ b/src/test/java/com/trendyTracker/util/UrlReaderTest.java
@@ -1,29 +1,28 @@
 package com.trendyTracker.util;
 
-import java.util.List;
 import java.util.Set;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 public class UrlReaderTest {
 
-    // @Test
-    // @DisplayName("url 정보 파싱")
-    // public void getUrlContent() throws Exception {
+    @Test
+    @DisplayName("url 정보 파싱")
+    public void getUrlContent() throws Exception {
         // given
-        // var testUrl = "https://www.owl-dev.me/blog/62";
+        var testUrl = "https://www.owl-dev.me/blog/62";
 
-        // // when
-        // Set<String> urlContent = UrlReader.getUrlContent(testUrl);
+        // when
+        Set<String> urlContent = UrlReader.getUrlContent(testUrl);
 
-        // // then
-        // Assertions.assertThat(urlContent.contains("Java")).isTrue();
+        // then
+        Assertions.assertThat(urlContent.contains("Java")).isTrue();
+        Assertions.assertThat(urlContent.contains("Python")).isTrue();
         
 
-    // }
+    }
 }


### PR DESCRIPTION
웹 스크래핑 관련 PlayWrit 대신 Selenium 으로 다시 변경합니다.
관련해서 Mac, RaspberryPi OS 의 chromeDriver를 능동적으로 처리하도록 수정합니다.

[변경 이유]
> 속도의 저하, playWrite 는 필수적으로 라이브러리에 크롬, 파이어폭스, 모질라 를 모두 설치해야하는 단점
> 내부의 라이브러리를 활용했음에도, 실질적으로 Docker 컨테이너에서 웹 스크래핑 실행 시, 동작 오류 발생하는점