### PR TITLE
어드민 API 토큰 로직 삽입

### DIFF
--- a/src/main/java/com/trendyTracker/common/config/InterCeptorConfig.java
+++ b/src/main/java/com/trendyTracker/common/config/InterCeptorConfig.java
@@ -1,0 +1,24 @@
+package com.trendyTracker.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class InterCeptorConfig implements WebMvcConfigurer{
+    @Value("${token.value}")
+    private String tokenValue;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry){
+        // JWT 토큰 검증을 적용할 URL 패턴 지정
+        registry.addInterceptor(new JwtInterceptor(tokenValue))
+            // Tech
+            .addPathPatterns("/api/tech/stack/create")
+            .addPathPatterns("/api/tech/stack/delete")
+            // Recruit
+            .addPathPatterns("/api/recruit/regist");         
+
+    }
+}

--- a/src/main/java/com/trendyTracker/common/config/JwtInterceptor.java
+++ b/src/main/java/com/trendyTracker/common/config/JwtInterceptor.java
@@ -1,0 +1,34 @@
+package com.trendyTracker.common.config;
+
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class JwtInterceptor implements HandlerInterceptor {
+    private String adminToken;
+
+    public JwtInterceptor(String adminToken){
+        this.adminToken = adminToken;
+    }
+    
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler){
+
+        // JWT 토큰 검증 로직 구현
+        String token = request.getHeader("Authorization");
+        if (token != null && token.startsWith("Bearer ")) {
+            String jwtToken = token.substring(7);
+
+            // Admin 토큰
+            if (jwtToken.equals(adminToken)) return true;
+
+            return false;
+        }
+        else {
+            // JWT 토큰이 없는 경우 처리
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Spring 의 Interceptior 를 활용해서 어드민 API는 특정 토큰을 가지고 있어야만 동작하도록 수정합니다.

**[API 종류]**
<img width="596" alt="image" src="https://github.com/Tech-Frontier/trendy-tracker-backend/assets/19955904/ea09d3fe-81af-4ed5-a2b8-67d1d84f6609">
```
/api/tech/stack/create
/api/tech/stack/delete

/api/recruit/regist
```

**[토큰이 없는 경우]**
<img width="678" alt="image" src="https://github.com/Tech-Frontier/trendy-tracker-backend/assets/19955904/0f36f6d7-a779-4af2-8a15-6a4ff392ca46">
