### PR TITLE
job total 건수 sigleton 관리

### DIFF
--- a/src/main/java/com/trendyTracker/Job/repository/JobRepository.java
+++ b/src/main/java/com/trendyTracker/Job/repository/JobRepository.java
@@ -20,4 +20,6 @@ public interface JobRepository {
 
     List<RecruitDto> getRecruitList(String[] companies, String[] jobCategories, String[] techs);
 
+    long getTotalJobCnt();
+
 }

--- a/src/main/java/com/trendyTracker/Job/repository/JobRepositoryImpl.java
+++ b/src/main/java/com/trendyTracker/Job/repository/JobRepositoryImpl.java
@@ -174,5 +174,17 @@ public class JobRepositoryImpl implements JobRepository {
         return recruitDtoList;
     }
 
+    @Override
+    public long getTotalJobCnt() {
+        queryFactory = new JPAQueryFactory(em);
+        QRecruit qRecruit = QRecruit.recruit;
+
+        var result = queryFactory.select(qRecruit.count())
+                                    .from(qRecruit)
+                                    .where(qRecruit.is_active.eq(true))
+                                    .fetchOne();
+        return result;
+    }
+
     //#endregion
 }

--- a/src/main/java/com/trendyTracker/Job/service/RecruitService.java
+++ b/src/main/java/com/trendyTracker/Job/service/RecruitService.java
@@ -16,6 +16,7 @@ import com.trendyTracker.Job.dto.RecruitDto;
 import com.trendyTracker.Job.repository.JobRepository;
 import com.trendyTracker.common.Exception.ExceptionDetail.NoResultException;
 import com.trendyTracker.common.Exception.ExceptionDetail.NotAllowedValueException;
+import com.trendyTracker.util.JobTotalCntSingleton;
 import com.trendyTracker.util.TechUtils;
 import com.trendyTracker.util.UrlReader;
 
@@ -26,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RecruitService {
     private final JobRepository jobRepository;
+    JobTotalCntSingleton jobTotalCntSingleton = JobTotalCntSingleton.getInstance();
 
      public long regisitJobPostion(String url, String companyName, String jobCategory) throws NoResultException, IOException {
     /*
@@ -36,6 +38,9 @@ public class RecruitService {
             throw new NoResultException("해당 url 에서 tech 가 발견되지 않았습니다");
 
         Company newCompany = jobRepository.registeCompany(companyName.toLowerCase());
+        // Singleton 데이터 변경
+        jobTotalCntSingleton.increaseCnt();
+
         return jobRepository.registJobPosition(url, newCompany, jobCategory.toLowerCase(), new ArrayList<>(techList));
     }
 
@@ -54,6 +59,9 @@ public class RecruitService {
      * 채용공고 비활성화 합니다.
      */
         var recruitInfo = getRecruitInfo(recruit_id);
+        // Singleton 데이터 변경
+        jobTotalCntSingleton.decreaseCnt();
+
         jobRepository.deleteJobPosition(recruitInfo.id());
     }
 
@@ -118,5 +126,14 @@ public class RecruitService {
             return recruitList.subList(startIndex, endIndex);    
         }
         return recruitList;
+    }
+
+    public long getTotalJobCnt(){
+        long totalJobCnt = jobRepository.getTotalJobCnt();
+
+        // Singleton 데이터 삽입
+        jobTotalCntSingleton.setTotalCnt(totalJobCnt);
+
+        return totalJobCnt;
     }
 }

--- a/src/main/java/com/trendyTracker/TrendyTrackerApplication.java
+++ b/src/main/java/com/trendyTracker/TrendyTrackerApplication.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.kafka.annotation.EnableKafka;
 
+import com.trendyTracker.Job.service.RecruitService;
 import com.trendyTracker.Job.service.TechService;
 
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TrendyTrackerApplication implements CommandLineRunner{
     private final TechService techService;
+    private final RecruitService recruitService;
 
     public static void main(String[] args) {
         SpringApplication.run(TrendyTrackerApplication.class, args);
@@ -25,7 +27,10 @@ public class TrendyTrackerApplication implements CommandLineRunner{
 
     @Override
     public void run(String... args) throws Exception {
-        System.out.println("get TechList!.");
+        System.out.println("init get TechList.");
         techService.getTechList();
+
+        System.out.println("init get total job cnt.");
+        recruitService.getTotalJobCnt();
     }
 }

--- a/src/main/java/com/trendyTracker/api/AppInfo/AppInfoController.java
+++ b/src/main/java/com/trendyTracker/api/AppInfo/AppInfoController.java
@@ -4,7 +4,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.trendyTracker.Appservice.domain.AppInfo;
 import com.trendyTracker.Appservice.service.AppInfoService;
 import com.trendyTracker.common.config.Loggable;
 import com.trendyTracker.common.response.Response;

--- a/src/main/java/com/trendyTracker/api/Recruit/RecruitController.java
+++ b/src/main/java/com/trendyTracker/api/Recruit/RecruitController.java
@@ -21,6 +21,7 @@ import com.trendyTracker.common.Exception.ExceptionDetail.NoResultException;
 import com.trendyTracker.common.Exception.ExceptionDetail.NotAllowedValueException;
 import com.trendyTracker.common.config.Loggable;
 import com.trendyTracker.common.response.Response;
+import com.trendyTracker.util.JobTotalCntSingleton;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -89,8 +90,11 @@ public class RecruitController {
 
         List<RecruitDto> recruitList = recruitService.getRecruitList(companies,jobCategories,techs,pageNo,pageSize);
         HashMap<String,Object> result = new HashMap<>();
-        result.put("totalCount", recruitList.size());
+        // Singleton 데이터 조회
+        JobTotalCntSingleton jobTotalCntSingleton = JobTotalCntSingleton.getInstance();
+        
         result.put("recruitList", recruitList);
+        result.put("totalCount", jobTotalCntSingleton.getTotalCnt());
 
         return Response.success(200, "공고 목록이 조회되었습니다", result);
     }

--- a/src/main/java/com/trendyTracker/util/JobTotalCntSingleton.java
+++ b/src/main/java/com/trendyTracker/util/JobTotalCntSingleton.java
@@ -1,0 +1,29 @@
+package com.trendyTracker.util;
+
+public class JobTotalCntSingleton {
+    private static JobTotalCntSingleton instance;
+    private long totalJobCnt;
+
+    public static JobTotalCntSingleton getInstance(){
+        if( instance == null)
+            instance = new JobTotalCntSingleton();
+
+        return instance;
+    }
+
+    public void setTotalCnt(long cnt){
+        this.totalJobCnt =cnt;
+    }
+
+    public long getTotalCnt(){
+        return totalJobCnt;
+    }
+
+    public void increaseCnt(){
+        totalJobCnt = totalJobCnt +1;
+    }
+
+    public void decreaseCnt(){
+        totalJobCnt = totalJobCnt-1;
+    }
+}


### PR DESCRIPTION
채용공고의 건수 관련 항상 전체 채용공고 건수를 조회하도록 수정합니다.
- 전체 건수 관련 Signleton 객체를 만들어, 불필요한 DB 트랜잭션을 방지하고 메모리 사용량을 줄입니다.