### PR TITLE
채용공고 등록 API 이벤트 기반으로 변경

### DIFF
--- a/src/main/java/com/trendyTracker/common/kafka/KafkaConsumer.java
+++ b/src/main/java/com/trendyTracker/common/kafka/KafkaConsumer.java
@@ -1,23 +1,41 @@
 package com.trendyTracker.common.kafka;
 
+import java.io.IOException;
+
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trendyTracker.Job.service.RecruitService;
+import com.trendyTracker.common.Exception.ExceptionDetail.NoResultException;
 
 @Service
 public class KafkaConsumer {
+    @Autowired
+    private RecruitService recruitService;
+    static Logger logger = LoggerFactory.getLogger(KafkaConsumer.class);
 
-    // @KafkaListener(topics = "logger", groupId = "my-group")
-    // public void listenToTopic1(ConsumerRecord<String, String> record) {
-    //     String key = record.key();
-    //     String value = record.value();
-    //     System.out.println("Received message - Key: " + key + ", Value: " + value);
-    // }
+    @KafkaListener(topics = "RegistJob", groupId = "my-group")
+    public void listenToRegistJob(ConsumerRecord<String, String> record, @Header(name = "uuid") String uuid) throws NoResultException, IOException {
+    /*
+     * 채용공고 등록
+     */
+        String value = record.value();
 
-    // @KafkaListener(topics = "error", groupId = "my-group")
-    // public void listenToTopic2(ConsumerRecord<String, String> record) {
-    //     String key = record.key();
-    //     String value = record.value();
-    //     System.out.println("Received message - Key: " + key + ", Value: " + value);
-    // }
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(value);
+        String url = jsonNode.get("url").asText();
+        String company = jsonNode.get("company").asText();
+        String occupation = jsonNode.get("occupation").asText();
+
+
+        long id = recruitService.regisitJobPostion(url, company, occupation);
+        logger.info("Consumed RegistJob Topic: id:" + id + " header: " + uuid);
+    }
 }

--- a/src/main/java/com/trendyTracker/common/kafka/KafkaProducer.java
+++ b/src/main/java/com/trendyTracker/common/kafka/KafkaProducer.java
@@ -1,11 +1,15 @@
 package com.trendyTracker.common.kafka;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Service
 public class KafkaProducer {
@@ -16,11 +20,29 @@ public class KafkaProducer {
     }
 
     public void sendMessage(String topic, String key, String value, String header) {
+    /*
+     * Logging   
+     */
         ProducerRecord<String, String> record = new ProducerRecord<>(topic, null, key, value);
 
         RecordHeader recordHeader = new RecordHeader("uuid", header.getBytes(StandardCharsets.UTF_8));
         record.headers().add(recordHeader);
 
+        kafkaTemplate.send(record);
+    }
+
+    public void sendMessage(String topic, Map<String,String> messageMap, String header) throws JsonProcessingException{
+    /*
+     * 채용공고 등록
+     */
+        ObjectMapper objectMapper = new ObjectMapper();
+        String message = objectMapper.writeValueAsString(messageMap);
+
+        ProducerRecord<String, String> record = new ProducerRecord<>(topic, message);
+
+        RecordHeader recordHeader = new RecordHeader("uuid", header.getBytes(StandardCharsets.UTF_8));
+        record.headers().add(recordHeader);
+        
         kafkaTemplate.send(record);
     }
 }

--- a/src/main/java/com/trendyTracker/common/logstash/logstash.conf
+++ b/src/main/java/com/trendyTracker/common/logstash/logstash.conf
@@ -1,7 +1,7 @@
 input {
   kafka {
     bootstrap_servers => "kafka-1:29092, kafka-2:29093, kafka-2:29094"
-    topics => ["logger", "error"]
+    topics => ["logger", "error", "RegistJob"]
     decorate_events => true
   }
 }


### PR DESCRIPTION
## 요약
1. 채용공고 등록 API 를 이벤트 기반으로 변경합니다.

![image](https://github.com/Tech-Frontier/trendy-tracker-backend/assets/19955904/b1f56db9-6f48-4b59-863c-e4a115e56889)

* 이렇게 함으로써 대규모의 채용공고 요청이 들어와도, kafka 의 작업 Queue 에 등록되고 라즈베리파이가 감당할 수 있는 리소스 정도로만 순차적으로 진행되게끔 합니다.

* Consumer 에서 처리되는것에 대한 이벤트 관리는, logger 를 통한 파일과, Elasticsearch 에 같이 관리됩니다.