### PR TITLE
채용공고 등록관련 속도 개선 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       - '9092:9092'
     depends_on:
       - zookeeper-1
+    container_name: kafka-1
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:32181
@@ -69,6 +70,8 @@ services:
       KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-1:29092,EXTERNAL://localhost:9092
       KAFKA_DEFAULT_REPLICATION_FACTOR: 3
       KAFKA_NUM_PARTITIONS: 3
+    volumes:
+      - ./kafka-1-data:/var/lib/kafka/data
 
   kafka-2:
     image: confluentinc/cp-kafka:7.2.2.arm64
@@ -76,6 +79,7 @@ services:
       - '9093:9093'
     depends_on:
       - zookeeper-1
+    container_name: kafka-2
     environment:
       KAFKA_BROKER_ID: 2
       KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:32181
@@ -84,6 +88,8 @@ services:
       KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-2:29093,EXTERNAL://localhost:9093
       KAFKA_DEFAULT_REPLICATION_FACTOR: 3
       KAFKA_NUM_PARTITIONS: 3
+    volumes:
+      - ./kafka-2-data:/var/lib/kafka/data
     
   kafka-3:
     image: confluentinc/cp-kafka:7.2.2.arm64
@@ -91,6 +97,7 @@ services:
       - '9094:9094'
     depends_on:
       - zookeeper-1
+    container_name: kafka-3
     environment:
       KAFKA_BROKER_ID: 3
       KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:32181
@@ -99,6 +106,8 @@ services:
       KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-3:29094,EXTERNAL://localhost:9094
       KAFKA_DEFAULT_REPLICATION_FACTOR: 3
       KAFKA_NUM_PARTITIONS: 3
+    volumes:
+      - ./kafka-3-data:/var/lib/kafka/data
 
   kafka-ui:
     image: provectuslabs/kafka-ui

--- a/src/main/java/com/trendyTracker/infrastructure/kafka/KafkaConsumer.java
+++ b/src/main/java/com/trendyTracker/infrastructure/kafka/KafkaConsumer.java
@@ -21,21 +21,27 @@ public class KafkaConsumer {
     private RecruitService recruitService;
     static Logger logger = LoggerFactory.getLogger(KafkaConsumer.class);
 
-    @KafkaListener(topics = "RegistJob", groupId = "my-group")
+    @KafkaListener(topics = "RegistJob", groupId = "my-group", concurrency = "3")
     public void listenToRegistJob(ConsumerRecord<String, String> record, @Header(name = "uuid") String uuid) throws NoResultException, IOException {
     /*
      * 채용공고 등록
      */
-        String value = record.value();
+        try{
+            String value = record.value();
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode jsonNode = objectMapper.readTree(value);
-        String url = jsonNode.get("url").asText();
-        String company = jsonNode.get("company").asText();
-        String occupation = jsonNode.get("occupation").asText();
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode jsonNode = objectMapper.readTree(value);
+            String url = jsonNode.get("url").asText();
+            String company = jsonNode.get("company").asText();
+            String occupation = jsonNode.get("occupation").asText();
 
 
-        long id = recruitService.regisitJobPostion(url, company, occupation);
-        logger.info("Consumed RegistJob Topic: id:" + id + " header: " + uuid);
+            long id = recruitService.regisitJobPostion(url, company, occupation);
+            logger.info("Consumed RegistJob Topic: id:" + id + " header: " + uuid);
+        
+        }catch (Exception ex){
+            logger.error(uuid, ex.getMessage());
+        }
+
     }
 }

--- a/src/main/java/com/trendyTracker/util/UrlReader.java
+++ b/src/main/java/com/trendyTracker/util/UrlReader.java
@@ -90,7 +90,7 @@ public class UrlReader {
             else if (osName.contains("linux"))
                 serviceBuilder.usingDriverExecutable(new File("/usr/local/bin/chromedriver"));
             
-            ChromeDriverService service = serviceBuilder.usingPort(9516).build();
+            ChromeDriverService service = serviceBuilder.build();
             service.start();
             
             ChromeOptions options = new ChromeOptions();


### PR DESCRIPTION
**[요약]**
- Apach Kafka 의 채용공고 Topic 을 구독하는 컨슈머 개수를 조정합니다.
- Kafka 브로커에 Docker Volume 을 지정해서 트러블 슈팅에 용이하게 합니다 
- Selenium 을 활용한 웹 Url 스크래핑에서 특정 port 로 지정하던것을 해제 합니다 

**[이슈]**
채용공고 Url 를 Produce 하는 쪽은 시간이 적게걸리는데 반해, 구독하는 Consumer 입장에서는 채용공고를 가져와 스크래핑하는 과정에서
시간이 상대적으로 오래 걸립니다.

**[수정 방향]**
- Trendy-Tracker 의 현재 구조는 3개의 kafka broker 를 통해 kafka cluster 가 구성되어 있으며, 해당 Topic 의 파티션은 3개로 지정해두었으나 기존에는 1개의 컨슈머로 파티션 한개만 사용하는 비효율이 있었습니다.  컨슈머는 1개당 1개의 Thread 를 사용하기에 해당 컨슈머 그룹의 컨슈머의 쓰레드를 3개로 사용해서 토픽에 할당된 3개의 파티션을 모두 활용하도록 수정합니다 

- Web Scrapping 과정에서 특정 포트만 사용하던 것을 제한하여 동시에 여러 공고를 스크래핑 할 수 있도록 수정합니다.

**[Tip]**
* 파티션 개수보다 컨슈머 개수를 더 많이 늘려도, 파티션 개수를 넘는 컨슈머는 놀게 된다 (속도 개선 X)
* 컨슈머 그룹 개수를 여러개로 늘리면 Scale Out 의 효과를 기대할 수 있으나 현재 하나의 애플리케이션에서 이렇게 하는것은 Anti-Pattern 에 가깝다고 판단 + 향후 순서 보장 이슈 발생  
