### PR TITLE
recruit 테이블 인덱스 생성

### DIFF
--- a/src/main/java/com/trendyTracker/Job/domain/Recruit.java
+++ b/src/main/java/com/trendyTracker/Job/domain/Recruit.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
@@ -23,7 +24,9 @@ import lombok.Setter;
 
 @Getter @Setter
 @Entity
-@Table(name ="recruit", schema = "public")
+@Table(name = "recruit", schema = "public", indexes = {
+    @Index(name = "idx_company_jobCategory", columnList = "company_id, jobCategory")
+})
 @NoArgsConstructor
 public class Recruit {
     @Id


### PR DESCRIPTION
**[요약]**
recruit 테이블에 company_id, job_category 칼럼에 대한 복합키 인덱스를 생성합니다.

```
CREATE TABLE public.recruit (
	is_active bool NULL,
	company_id int8 NULL,
	create_time timestamp(6) NULL,
	recruit_id int8 NOT NULL,
	updated_time timestamp(6) NULL,
	url varchar(300) NULL,
	job_category varchar(255) NULL,
	title varchar(255) NULL,
	CONSTRAINT recruit_pkey PRIMARY KEY (recruit_id)
);
CREATE INDEX idx_company_jobcategory ON public.recruit USING btree (company_id, job_category);

```