### PR TITLE
회사 그룹을 추가합니다

### DIFF
--- a/src/main/java/com/trendyTracker/Job/domain/Company.java
+++ b/src/main/java/com/trendyTracker/Job/domain/Company.java
@@ -2,8 +2,12 @@ package com.trendyTracker.Job.domain;
 
 import java.time.LocalDateTime;
 
+import com.trendyTracker.Job.domain.Model.CompanyInfo;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
@@ -14,10 +18,25 @@ import lombok.Setter;
 @Entity
 @Table(name = "company" ,schema="public")
 public class Company {
+
+    public enum CompanyCategory {
+        Series_PreA,
+        Series_A,
+        Series_B,
+        Series_C,
+        Series_D,
+        Listed,
+    }
+
     @Id
     @GeneratedValue
     @Column(name ="company_id")
     private long id;
+
+    private String companyGroup;
+
+    @Enumerated(EnumType.STRING) 
+    private CompanyCategory companyCategory;
 
     @Column(name="company_name", unique = true)
     private String company_name;
@@ -25,8 +44,20 @@ public class Company {
     private LocalDateTime updated_time;
 
     // 연관관계 메서드
-    public void addCompany(String company_name){
-        this.company_name = company_name;
+    public void addCompany(CompanyInfo companyInfo){
+        this.companyGroup = companyInfo.companyGroup();
+        this.companyCategory = companyInfo.companyCategory();
+        this.company_name = companyInfo.companyName();
+        this.updated_time = LocalDateTime.now();
+    }
+
+    public void updateCategory(CompanyCategory category){
+        this.companyCategory = category;
+        this.updated_time = LocalDateTime.now();
+    }
+
+    public void updateGroup(String group){
+        this.companyGroup = group;
         this.updated_time = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/trendyTracker/Job/domain/Model/CompanyInfo.java
+++ b/src/main/java/com/trendyTracker/Job/domain/Model/CompanyInfo.java
@@ -1,0 +1,17 @@
+package com.trendyTracker.Job.domain.Model;
+
+import com.trendyTracker.Job.domain.Company.CompanyCategory;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CompanyInfo (
+    @Schema(description = "회사 그룹", example = "Naver")
+    String companyGroup,
+
+    @Schema(description = "회사 규모", example = "Series_C")
+    CompanyCategory companyCategory,
+
+    @Schema(description = "회사 규모", example = "Naver_Webtoon")
+    String companyName
+){
+}

--- a/src/main/java/com/trendyTracker/Job/dto/CompanyTechStackDto.java
+++ b/src/main/java/com/trendyTracker/Job/dto/CompanyTechStackDto.java
@@ -6,8 +6,13 @@ import java.util.Map;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record CompanyTechStackDto(
-        @Schema(description = "회사명", example = "네이버") String company,
-        @Schema(description = "회사별 개발 스택", example = "[C#, .Net, WPF]") List<String> stackByCompany,
-        @Schema(description = "공고별 개발 스택", example = "{'https://naver.com', [C#, .Net, WPF]") Map<String, List<String>> stackByUrl
+        @Schema(description = "회사명", example = "네이버") 
+        String company,
+
+        @Schema(description = "회사별 개발 스택", example = "[C#, .Net, WPF]") 
+        List<String> stackByCompany,
+        
+        @Schema(description = "공고별 개발 스택", example = "{'https://naver.com', [C#, .Net, WPF]") 
+        Map<String, List<String>> stackByUrl
 ) {
 }

--- a/src/main/java/com/trendyTracker/Job/repository/JobRepository.java
+++ b/src/main/java/com/trendyTracker/Job/repository/JobRepository.java
@@ -6,9 +6,10 @@ import java.util.Optional;
 import com.trendyTracker.Job.domain.Company;
 import com.trendyTracker.Job.domain.Recruit;
 import com.trendyTracker.Job.domain.Tech;
+import com.trendyTracker.Job.domain.Model.CompanyInfo;
 
 public interface JobRepository {
-    Company registeCompany(String company);
+    Company registeCompany(CompanyInfo companyInfo);
 
     Recruit registJobPosition(String url, String title, Company company, String jobPosition, List<Tech> techList);
 

--- a/src/main/java/com/trendyTracker/Job/repository/JobRepositoryImpl.java
+++ b/src/main/java/com/trendyTracker/Job/repository/JobRepositoryImpl.java
@@ -11,6 +11,7 @@ import com.trendyTracker.Job.domain.QRecruit;
 import com.trendyTracker.Job.domain.Recruit;
 import com.trendyTracker.Job.domain.RecruitTech;
 import com.trendyTracker.Job.domain.Tech;
+import com.trendyTracker.Job.domain.Model.CompanyInfo;
 
 import org.springframework.stereotype.Repository;
 
@@ -30,7 +31,7 @@ public class JobRepositoryImpl implements JobRepository {
     //#region [CREATE]
     @Override
     @Transactional
-    public Company registeCompany(String company) {
+    public Company registeCompany(CompanyInfo companyInfo) {
     /*
      * 'Company' 저장
      */
@@ -40,13 +41,13 @@ public class JobRepositoryImpl implements JobRepository {
         
         var findCompany = queryFactory.select(qCompany)
                 .from(qCompany)
-                .where(qCompany.company_name.eq(company))
+                .where(qCompany.company_name.eq(companyInfo.companyName()))
                 .fetchOne();
 
         if (findCompany != null)
             return findCompany;
 
-        newCompany.addCompany(company);
+        newCompany.addCompany(companyInfo);
         em.persist(newCompany);
         return newCompany;
     }
@@ -200,5 +201,6 @@ public class JobRepositoryImpl implements JobRepository {
                                     .fetchOne();
         return result;
     }
+
     //#endregion
 }

--- a/src/main/java/com/trendyTracker/Job/repository/KafkaConsumerImpl.java
+++ b/src/main/java/com/trendyTracker/Job/repository/KafkaConsumerImpl.java
@@ -14,8 +14,10 @@ import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trendyTracker.Job.domain.Model.CompanyInfo;
 import com.trendyTracker.Job.service.RecruitService;
 import com.trendyTracker.infrastructure.kafka.KafkaProducer;
+import com.trendyTracker.util.CompanyUtils;
 
 
 @Service
@@ -35,12 +37,17 @@ public class KafkaConsumerImpl implements MessageConsumer<ConsumerRecord<String,
          */
         JsonNode jsonNode = new ObjectMapper().readTree(mesage.value());
         String url = jsonNode.get("url").asText();
+        
+        String companyGroup = jsonNode.get("companyGroup").asText();
+        String companyCategory = jsonNode.get("companyCategory").asText();
         String company = jsonNode.get("company").asText();
+
         String jobCategory = jsonNode.get("jobCategory").asText();
         String uuid = header.get();
         
         try{
-            long id = recruitService.regisitJobPostion(url, company, jobCategory);
+            var companyInfo = new CompanyInfo(companyGroup,CompanyUtils.makeCompanyCategory(companyCategory),company);
+            long id = recruitService.regisitJobPostion(url, companyInfo, jobCategory);
             logger.info("Consumed RegistJob Topic: id:" + id + " header: " + uuid);
         }
         catch (Exception ex){

--- a/src/main/java/com/trendyTracker/Job/service/RecruitService.java
+++ b/src/main/java/com/trendyTracker/Job/service/RecruitService.java
@@ -12,6 +12,7 @@ import org.webjars.NotFoundException;
 import com.trendyTracker.Job.domain.Company;
 import com.trendyTracker.Job.domain.Recruit;
 import com.trendyTracker.Job.domain.Tech;
+import com.trendyTracker.Job.domain.Model.CompanyInfo;
 import com.trendyTracker.Job.dto.JobInfoDto;
 import com.trendyTracker.Job.repository.JobRepository;
 import com.trendyTracker.common.Exception.ExceptionDetail.NoResultException;
@@ -29,20 +30,21 @@ public class RecruitService {
     private final JobRepository jobRepository;
     JobTotalCntSingleton jobTotalCntSingleton = JobTotalCntSingleton.getInstance();
 
-     public long regisitJobPostion(String url, String companyName, String jobCategory) throws NoResultException, IOException {
+    public long regisitJobPostion(String url, CompanyInfo companyInfo, String jobCategory) throws NoResultException, IOException {
      /*
       * url, company, jobCategory 를 활용해 채용공고 등록합니다
       */
         JobInfoDto jobInfo = UrlReader.getUrlContent(url);
         if (jobInfo.techSet().size() == 0)
             throw new NoResultException("해당 url 에서 tech 가 발견되지 않았습니다");
-
-        Company newCompany = jobRepository.registeCompany(companyName.toLowerCase());
+        
+        Company newCompany = jobRepository.registeCompany(companyInfo);
         // Singleton 데이터 변경
         jobTotalCntSingleton.increaseCnt();
+
         Recruit recruit = jobRepository.registJobPosition(url, jobInfo.title()
-                                                        , newCompany, jobCategory.toLowerCase()
-                                                        , new ArrayList<>(jobInfo.techSet()));
+                , newCompany, jobCategory.toLowerCase(), 
+                new ArrayList<>(jobInfo.techSet()));
 
         return recruit.getId();
     }

--- a/src/main/java/com/trendyTracker/api/Recruit/RecruitController.java
+++ b/src/main/java/com/trendyTracker/api/Recruit/RecruitController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.trendyTracker.Job.domain.Recruit;
+import com.trendyTracker.Job.domain.Company.CompanyCategory;
 import com.trendyTracker.Job.dto.RecruitDto;
 import com.trendyTracker.Job.service.RecruitService;
 import com.trendyTracker.common.Exception.ExceptionDetail.AlreadyExistException;
@@ -62,8 +63,11 @@ public class RecruitController {
 
         HashMap<String, String> paramMap = new HashMap<>();
         paramMap.put("url", recruitRequest.url);
-        paramMap.put("company", recruitRequest.company);
         paramMap.put("jobCategory", recruitRequest.jobCategory);
+
+        paramMap.put("companyGroup", recruitRequest.companyGroup);
+        paramMap.put("companyCategory", recruitRequest.companyCategory.name());
+        paramMap.put("company", recruitRequest.company);
 
         String uuid = addHeader(request, response);
         kafkaProducer.sendMessage("RegistJob", paramMap, uuid);    
@@ -191,7 +195,13 @@ public class RecruitController {
         @Schema(description = "Url", example = "https://toss.im/career/job-detail?job_id=4071141003&company=%ED%86%A0%EC%8A%A4%EB%B1%85%ED%81%AC&gh_src=a6133a833us&utm_source=offline_conference&utm_medium=banner&utm_campaign=2307_tossbank_recruit", type = "String")
         private String url;
 
-        @Schema(description = "회사명", example = "toss", type = "String")
+        @Schema(description = "회사그룹", example = "toss", type = "String")
+        private String companyGroup;
+
+        @Schema(description = "회사규모", example = "Series_D", type = "CompanyCategory")
+        private CompanyCategory companyCategory;
+        
+        @Schema(description = "회사명", example = "toss bank", type = "String")
         private String company;
 
         @Schema(description = "직군", example = "Backend", type = "String")

--- a/src/main/java/com/trendyTracker/util/CompanyUtils.java
+++ b/src/main/java/com/trendyTracker/util/CompanyUtils.java
@@ -1,0 +1,25 @@
+package com.trendyTracker.util;
+
+import com.trendyTracker.Job.domain.Company.CompanyCategory;
+
+public class CompanyUtils {
+
+    public static CompanyCategory makeCompanyCategory(String category){
+        switch (category) {
+            case "Series_PreA":
+                return CompanyCategory.Series_PreA;
+            case "Series_A":
+                return CompanyCategory.Series_A;
+            case "Series_B":
+                return CompanyCategory.Series_B;
+            case "Series_C":
+                return CompanyCategory.Series_C;
+            case "Series_D":
+                return CompanyCategory.Series_D;
+            case "Listed":
+                return CompanyCategory.Listed;
+            default:
+                throw new IllegalArgumentException("올바르지 않은 CompanyCategory 값: " + category);
+        }
+    }
+}   

--- a/src/test/java/com/trendyTracker/service/RecruitServiceTest.java
+++ b/src/test/java/com/trendyTracker/service/RecruitServiceTest.java
@@ -18,6 +18,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 
 import com.trendyTracker.Job.domain.Company;
 import com.trendyTracker.Job.domain.Recruit;
+import com.trendyTracker.Job.domain.Company.CompanyCategory;
+import com.trendyTracker.Job.domain.Model.CompanyInfo;
 import com.trendyTracker.Job.service.RecruitService;
 import com.trendyTracker.common.Exception.ExceptionDetail.NoResultException;
 import com.trendyTracker.common.Exception.ExceptionDetail.NotAllowedValueException;
@@ -44,8 +46,10 @@ public class RecruitServiceTest {
         Recruit tempRecruit1 = new Recruit();
         Recruit tempRecruit2 = new Recruit();
 
-        tempCompany1.addCompany("toss");
-        tempCompany2.addCompany("naver");
+        CompanyInfo companyInfo = new CompanyInfo(company, CompanyCategory.Series_D, "toss");
+        CompanyInfo companyInfo2 = new CompanyInfo(company, CompanyCategory.Series_A, "naver");
+        tempCompany1.addCompany(companyInfo);
+        tempCompany2.addCompany(companyInfo2);
         tempRecruit1.addRecruit(url, "title", tempCompany1, jobCategory);
         tempRecruit2.addRecruit(url, "title", tempCompany2, jobCategory);
 
@@ -55,7 +59,7 @@ public class RecruitServiceTest {
         String[] newTechs;
 
         // regisitJobPostion 
-        when(recruitService.regisitJobPostion(url, company, jobCategory))
+        when(recruitService.regisitJobPostion(url, companyInfo, jobCategory))
         .thenReturn((long)1);
 
         // getRecruitList
@@ -113,8 +117,11 @@ public class RecruitServiceTest {
     @Test
     @DisplayName("채용 공고 등록")
     public void regisitJobPostion() throws NoResultException, IOException{
-        // given, when 
-        long recruit_id = recruitService.regisitJobPostion(url, company, jobCategory);
+        // given
+        CompanyInfo companyInfo = new CompanyInfo(company, CompanyCategory.Series_D, "toss");        
+        
+        //when 
+        long recruit_id = recruitService.regisitJobPostion(url, companyInfo, jobCategory);
 
         // then 
         Assertions.assertThat(recruit_id).isGreaterThan(0);
@@ -241,7 +248,8 @@ public class RecruitServiceTest {
     @DisplayName("채용공고 재등록")
     public void updateJobPosition() throws IOException, NoResultException{
         // given
-        long recruit_id = recruitService.regisitJobPostion(url, company, jobCategory);
+        CompanyInfo companyInfo = new CompanyInfo(company, CompanyCategory.Series_D, "toss");    
+        long recruit_id = recruitService.regisitJobPostion(url, companyInfo, jobCategory);
         // when
         long result_id = recruitService.updateJobPosition(url);
         

--- a/src/test/java/com/trendyTracker/util/CompanyUtilsTest.java
+++ b/src/test/java/com/trendyTracker/util/CompanyUtilsTest.java
@@ -1,0 +1,29 @@
+package com.trendyTracker.util;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.trendyTracker.Job.domain.Company.CompanyCategory;
+
+public class CompanyUtilsTest {
+    @Test
+    void testMakeCompanyCategory() {
+        // given
+        String category = "Series_A";
+        // when 
+        CompanyCategory makeCompanyCategory = CompanyUtils.makeCompanyCategory(category);
+        // then 
+        Assertions.assertThat(makeCompanyCategory.name()).isEqualTo("Series_A");
+    }
+
+    @Test
+    void testMakeCompanyCategoryWithOtherValue() {
+        // given, when
+        // then 
+        assertThrows(IllegalArgumentException.class, () 
+                        -> CompanyUtils.makeCompanyCategory(""));
+        
+    }
+}


### PR DESCRIPTION
**[요약]**
- 아래 회사의 규모를 판단하는 companyCategory VO(Value Object) 를 추가합니다.
- 관련해서 Company 테이블에 관련 칼럼을 추가합니다
- 테스트 코드를 수정합니다

**[TODO]**
회사의 기준정보 (그룹명, 회사규모, 회사명) 을 등록 ,수정 하는 API  추가가 필요합니다.


```
public enum CompanyCategory {
        Series_PreA,
        Series_A,
        Series_B,
        Series_C,
        Series_D,
        Listed,
    }
```

**[Swagger]** 
![image](https://github.com/Tech-Frontier/trendy-tracker-backend/assets/19955904/9ef2c157-5c8d-4469-8b90-b43b7f6ed941)

**[ERD UDATE]**
![스크린샷 2023-10-28 오후 3 13 17](https://github.com/Tech-Frontier/trendy-tracker-backend/assets/19955904/b6b447b5-ced1-4cce-83fd-17cf7afa79cd)


