### PR TITLE
docker compose 분리합니다

### DIFF
--- a/docker-compose-infra.yml
+++ b/docker-compose-infra.yml
@@ -1,0 +1,94 @@
+version: '3.3'
+services:
+  logstash:
+    image: docker.elastic.co/logstash/logstash:8.1.2-arm64
+    container_name: logstash
+    volumes:
+      - ./src/main/java/com/trendyTracker/infrastructure/logstash:/usr/share/logstash/config
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.1.2-arm64
+    container_name: kibana
+    volumes:
+      - ./src/main/java/com/trendyTracker/infrastructure/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml
+    ports:
+      - "5601:5601"
+
+  zookeeper-1:
+    image: confluentinc/cp-zookeeper:7.2.2.arm64
+    ports:
+      - '32181:32181'
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 32181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka-1:
+    image: confluentinc/cp-kafka:7.2.2.arm64
+    ports:
+      - '9092:9092'
+    depends_on:
+      - zookeeper-1
+    container_name: kafka-1
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:32181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-1:29092,EXTERNAL://localhost:9092
+      KAFKA_DEFAULT_REPLICATION_FACTOR: 3
+      KAFKA_NUM_PARTITIONS: 3
+    volumes:
+      - ./kafka-1-data:/var/lib/kafka/data
+
+  kafka-2:
+    image: confluentinc/cp-kafka:7.2.2.arm64
+    ports:
+      - '9093:9093'
+    depends_on:
+      - zookeeper-1
+    container_name: kafka-2
+    environment:
+      KAFKA_BROKER_ID: 2
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:32181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-2:29093,EXTERNAL://localhost:9093
+      KAFKA_DEFAULT_REPLICATION_FACTOR: 3
+      KAFKA_NUM_PARTITIONS: 3
+    volumes:
+      - ./kafka-2-data:/var/lib/kafka/data
+    
+  kafka-3:
+    image: confluentinc/cp-kafka:7.2.2.arm64
+    ports:
+      - '9094:9094'
+    depends_on:
+      - zookeeper-1
+    container_name: kafka-3
+    environment:
+      KAFKA_BROKER_ID: 3
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:32181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-3:29094,EXTERNAL://localhost:9094
+      KAFKA_DEFAULT_REPLICATION_FACTOR: 3
+      KAFKA_NUM_PARTITIONS: 3
+    volumes:
+      - ./kafka-3-data:/var/lib/kafka/data
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui
+    container_name: kafka-ui
+    ports:
+      - "8989:8080"
+    restart: always
+    depends_on:
+      - zookeeper-1
+      - kafka-1
+      - kafka-2
+      - kafka-3
+    environment:
+      - KAFKA_CLUSTERS_0_NAME=local
+      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka-1:29092 ,kafka-2:29093,kafka-3:29094
+      - KAFKA_CLUSTERS_0_ZOOKEEPER=zookeeper-1:22181

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,6 @@
 version: '3.3'
 services:
-  logstash:
-    image: docker.elastic.co/logstash/logstash:8.1.2-arm64
-    container_name: logstash
-    volumes:
-      - ./src/main/java/com/trendyTracker/infrastructure/logstash:/usr/share/logstash/config
-
-  kibana:
-    image: docker.elastic.co/kibana/kibana:8.1.2-arm64
-    container_name: kibana
-    volumes:
-      - ./src/main/java/com/trendyTracker/infrastructure/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml
-    ports:
-      - "5601:5601"
-
+  
   trendy_tracker:
     image: jinsujj/trendy-tracker-backend:latest
     ports:
@@ -47,81 +34,34 @@ services:
       JWT_SECRET_KEY: 
 
 
-  zookeeper-1:
-    image: confluentinc/cp-zookeeper:7.2.2.arm64
+  trendy_tracker2:
+    image: jinsujj/trendy-tracker-backend:latest
     ports:
-      - '32181:32181'
-    container_name: zookeeper
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 32181
-      ZOOKEEPER_TICK_TIME: 2000
-
-  kafka-1:
-    image: confluentinc/cp-kafka:7.2.2.arm64
-    ports:
-      - '9092:9092'
-    depends_on:
-      - zookeeper-1
-    container_name: kafka-1
-    environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:32181
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
-      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-1:29092,EXTERNAL://localhost:9092
-      KAFKA_DEFAULT_REPLICATION_FACTOR: 3
-      KAFKA_NUM_PARTITIONS: 3
-    volumes:
-      - ./kafka-1-data:/var/lib/kafka/data
-
-  kafka-2:
-    image: confluentinc/cp-kafka:7.2.2.arm64
-    ports:
-      - '9093:9093'
-    depends_on:
-      - zookeeper-1
-    container_name: kafka-2
-    environment:
-      KAFKA_BROKER_ID: 2
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:32181
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
-      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-2:29093,EXTERNAL://localhost:9093
-      KAFKA_DEFAULT_REPLICATION_FACTOR: 3
-      KAFKA_NUM_PARTITIONS: 3
-    volumes:
-      - ./kafka-2-data:/var/lib/kafka/data
-    
-  kafka-3:
-    image: confluentinc/cp-kafka:7.2.2.arm64
-    ports:
-      - '9094:9094'
-    depends_on:
-      - zookeeper-1
-    container_name: kafka-3
-    environment:
-      KAFKA_BROKER_ID: 3
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:32181
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
-      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-3:29094,EXTERNAL://localhost:9094
-      KAFKA_DEFAULT_REPLICATION_FACTOR: 3
-      KAFKA_NUM_PARTITIONS: 3
-    volumes:
-      - ./kafka-3-data:/var/lib/kafka/data
-
-  kafka-ui:
-    image: provectuslabs/kafka-ui
-    container_name: kafka-ui
-    ports:
-      - "8989:8080"
+      - '8080:8081'
     restart: always
+    container_name: trendy_tracker
     depends_on:
       - zookeeper-1
       - kafka-1
       - kafka-2
-      - kafka-3
+      - kibana
+    network_mode: host
     environment:
-      - KAFKA_CLUSTERS_0_NAME=local
-      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka-1:29092 ,kafka-2:29093,kafka-3:29094
-      - KAFKA_CLUSTERS_0_ZOOKEEPER=zookeeper-1:22181
+      SERVER_PORT: 8081
+      SPRING_DATASOURCE_URL: jdbc:postgresql://000.0.00.000:0000/
+      SPRING_DATASOURCE_USERNAME: 
+      SPRING_DATASOURCE_PASSWORD: 
+      SPRING_DATASOURCE_DRIVER_CLASS_NAME:  org.postgresql.Driver
+      TOKEN_VALUE: 
+      SPRING_JPA_HIBERNATE_DDL_AUTO: update
+      SPRING_JPA_HIBERNATE_SHOW_SQL: "off"
+      SPRING_JPA_HIBERNATE_FORMAT_SQL: "off"
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: localhost:9092,localhost:9093,localhost:9094
+      LOGGING_LEVEL_ORG_APACHE_KAFKA: "off"
+      MAIL_HOST: smtp.daum.net
+      MAIL_PORT: 465
+      MAIL_USERNAME: 
+      MAIL_PASSWORD: 
+      MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE: "true"
+      MAIL_PROPERTIES_MAIL_SMTP_AUTH:  "true"
+      JWT_SECRET_KEY:     


### PR DESCRIPTION
**[요약]**
Trendy-Tracker 백엔드 서버를 2개를 늘리기 위한 Docker-Compose 파일을 분리합니다.
관련해서 Nginx Health-Check 를 활용한 로드밸런싱을 구현합니다. 

**[현재 서버 health-check 경로]**
https://api.trendy-tracker.kr/status

- docker-compose.yml
- docker-compose-infra.yml
- docker-compose-elasticsearch.yml