### PR TITLE
엔티티 객체 생성자 적용합니다.

### DIFF
--- a/src/main/java/com/trendyTracker/Job/domain/Company.java
+++ b/src/main/java/com/trendyTracker/Job/domain/Company.java
@@ -1,9 +1,6 @@
 package com.trendyTracker.Job.domain;
 
-import java.time.LocalDateTime;
-
 import com.trendyTracker.Job.domain.Model.CompanyInfo;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -11,53 +8,58 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Getter @Setter
+@Getter
+@Setter
 @Entity
-@Table(name = "company" ,schema="public")
+@Table(name = "company", schema = "public")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Company {
 
-    public enum CompanyCategory {
-        Series_PreA,
-        Series_A,
-        Series_B,
-        Series_C,
-        Series_D,
-        Listed,
-    }
+  public enum CompanyCategory {
+    Series_PreA,
+    Series_A,
+    Series_B,
+    Series_C,
+    Series_D,
+    Listed,
+  }
 
-    @Id
-    @GeneratedValue
-    @Column(name ="company_id")
-    private long id;
+  @Id
+  @GeneratedValue
+  @Column(name = "company_id")
+  private long id;
 
-    private String company_group;
+  private String company_group;
 
-    @Enumerated(EnumType.STRING) 
-    private CompanyCategory company_category;
+  @Enumerated(EnumType.STRING)
+  private CompanyCategory company_category;
 
-    @Column(name="company_name", unique = true)
-    private String company_name;
+  @Column(name = "company_name", unique = true)
+  private String company_name;
 
-    private LocalDateTime updated_time;
+  private LocalDateTime updated_time;
 
-    // 연관관계 메서드
-    public void addCompany(CompanyInfo companyInfo){
-        this.company_group = companyInfo.companyGroup();
-        this.company_category = companyInfo.companyCategory();
-        this.company_name = companyInfo.companyName();
-        this.updated_time = LocalDateTime.now();
-    }
+  public Company(CompanyInfo companyInfo) {
+    this.company_group = companyInfo.companyGroup();
+    this.company_category = companyInfo.companyCategory();
+    this.company_name = companyInfo.companyName();
+    this.updated_time = LocalDateTime.now();
+  }
 
-    public void updateCategory(CompanyCategory category){
-        this.company_category = category;
-        this.updated_time = LocalDateTime.now();
-    }
+  // 연관관계 메서드
+  public void updateCategory(CompanyCategory category) {
+    this.company_category = category;
+    this.updated_time = LocalDateTime.now();
+  }
 
-    public void updateGroup(String group){
-        this.company_group = group;
-        this.updated_time = LocalDateTime.now();
-    }
+  public void updateGroup(String group) {
+    this.company_group = group;
+    this.updated_time = LocalDateTime.now();
+  }
 }

--- a/src/main/java/com/trendyTracker/Job/domain/Recruit.java
+++ b/src/main/java/com/trendyTracker/Job/domain/Recruit.java
@@ -1,12 +1,5 @@
 package com.trendyTracker.Job.domain;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -18,74 +11,98 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
-@Getter @Setter
+@Getter
+@Setter
 @Entity
-@Table(name = "recruit", schema = "public", indexes = {
-    @Index(name = "idx_company_jobCategory", columnList = "company_id, jobCategory"),
-    @Index(name = "idx_url", columnList = "url", unique = true) 
-})
-@NoArgsConstructor
+@Table(
+  name = "recruit",
+  schema = "public",
+  indexes = {
+    @Index(
+      name = "idx_company_jobCategory",
+      columnList = "company_id, jobCategory"
+    ),
+    @Index(name = "idx_url", columnList = "url", unique = true),
+  }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Recruit {
-    @Id
-    @GeneratedValue
-    @Column(name ="recruit_id")
-    private long id;
 
-    @OneToMany(mappedBy = "recruit", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private List<RecruitTech> urlTechs;
-    
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name ="company_id")
-    @OnDelete(action = OnDeleteAction.CASCADE)
-    private Company company;
+  @Id
+  @GeneratedValue
+  @Column(name = "recruit_id")
+  private long id;
 
-    private String jobCategory;
+  @OneToMany(
+    mappedBy = "recruit",
+    fetch = FetchType.LAZY,
+    cascade = CascadeType.ALL
+  )
+  private List<RecruitTech> urlTechs;
 
-    @Column(length = 300)
-    private String url;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "company_id")
+  @OnDelete(action = OnDeleteAction.CASCADE)
+  private Company company;
 
-    private String title;
+  private String jobCategory;
 
-    private LocalDateTime create_time;
+  @Column(length = 300)
+  private String url;
 
-    private LocalDateTime updated_time;
+  private String title;
 
-    private Boolean is_active;
+  private LocalDateTime create_time;
 
-    // 연관관계 메서드
-    public void addRecruit(String url, String title, Company company, String jobCategory){
-        this.url = url;
-        this.title = title;
-        this.company = company;
-        this.jobCategory = jobCategory;
-        this.create_time = LocalDateTime.now();
-        this.is_active = true;
+  private LocalDateTime updated_time;
+
+  private Boolean is_active;
+
+  public Recruit(
+    String url,
+    String title,
+    Company company,
+    String jobCategory
+  ) {
+    this.url = url;
+    this.title = title;
+    this.company = company;
+    this.jobCategory = jobCategory;
+    this.create_time = LocalDateTime.now();
+    this.is_active = true;
+  }
+
+  // 연관관계 메서드
+  public void updateUrlTechs(List<Tech> techsList) {
+    List<RecruitTech> newRecruitTechs = new ArrayList<>();
+
+    for (Tech tech : techsList) {
+      RecruitTech recruitTech = new RecruitTech(this, tech);
+      newRecruitTechs.add(recruitTech);
     }
-    
-    public void updateUrlTechs(List<Tech> techsList){
-        List<RecruitTech> newRecruitTechs = new ArrayList<>();
 
-        for (Tech tech : techsList) {
-            RecruitTech recruitTech = new RecruitTech();
-            recruitTech.addRecruitTech(this, tech);
-            newRecruitTechs.add(recruitTech);
-        }
-        this.urlTechs = newRecruitTechs;
-    }
+    this.urlTechs = newRecruitTechs;
+  }
 
-    public List<String> getTechList(){
-        List<String> techList = new ArrayList<String>();
-        for (RecruitTech recruitTech : urlTechs) {
-            techList.add(recruitTech.getTech().getTech_name());
-        }
-        return techList;
+  public List<String> getTechList() {
+    List<String> techList = new ArrayList<String>();
+    for (RecruitTech recruitTech : urlTechs) {
+      techList.add(recruitTech.getTech().getTech_name());
     }
+    return techList;
+  }
 
-    public void deleteRecruit(){
-        this.is_active =false;
-    }
+  public void deleteRecruit() {
+    this.is_active = false;
+  }
 }

--- a/src/main/java/com/trendyTracker/Job/domain/RecruitTech.java
+++ b/src/main/java/com/trendyTracker/Job/domain/RecruitTech.java
@@ -1,8 +1,5 @@
 package com.trendyTracker.Job.domain;
 
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -11,31 +8,36 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
-@Getter @Setter
+@Getter
+@Setter
 @Entity
-@Table(name ="recruit_tech", schema = "public")
+@Table(name = "recruit_tech", schema = "public")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RecruitTech {
 
-    @Id
-    @GeneratedValue
-    @Column(name ="recruit_tech_id")
-    private long id;
+  @Id
+  @GeneratedValue
+  @Column(name = "recruit_tech_id")
+  private long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name ="recruit_id")
-    @OnDelete(action = OnDeleteAction.CASCADE)
-    private Recruit recruit;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "recruit_id")
+  @OnDelete(action = OnDeleteAction.CASCADE)
+  private Recruit recruit;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name ="tech_name")
-    private Tech tech;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "tech_name")
+  private Tech tech;
 
-    // 연관관계 메서드
-    public void addRecruitTech(Recruit recruit, Tech tech){
-        this.recruit = recruit;
-        this.tech = tech;
-    }
+  public RecruitTech(Recruit recruit, Tech tech) {
+    this.recruit = recruit;
+    this.tech = tech;
+  }
 }

--- a/src/main/java/com/trendyTracker/Job/domain/Tech.java
+++ b/src/main/java/com/trendyTracker/Job/domain/Tech.java
@@ -6,36 +6,38 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Getter @Setter
+@Getter
+@Setter
 @Entity
-@Table(name ="tech", schema = "public")
-@NoArgsConstructor
+@Table(name = "tech", schema = "public")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Tech {
 
-    public enum TechType {
-        LANGUAGE,
-        DATABASE,
-        FRAMEWORK,
-        LIBRARIES,
-        TOOLS,
-        IDE,
-        OTHER
-    }
+  public enum TechType {
+    LANGUAGE,
+    DATABASE,
+    FRAMEWORK,
+    LIBRARIES,
+    TOOLS,
+    IDE,
+    OTHER,
+  }
 
-    @Id
-    @Column(name="tech_name", unique = true)
-    private String tech_name;
+  @Id
+  @Column(name = "tech_name", unique = true)
+  private String tech_name;
 
-    @Enumerated(EnumType.STRING) 
-    private TechType type;
+  @Enumerated(EnumType.STRING)
+  private TechType type;
 
-    // 연관관계 메서드
-    public Tech(String tech, TechType type){
-        this.tech_name = tech;
-        this.type = type;
-    }
+  // 연관관계 메서드
+  public Tech(String tech, TechType type) {
+    this.tech_name = tech;
+    this.type = type;
+  }
 }

--- a/src/main/java/com/trendyTracker/Job/repository/CompanyRepositoryImpl.java
+++ b/src/main/java/com/trendyTracker/Job/repository/CompanyRepositoryImpl.java
@@ -1,154 +1,162 @@
 package com.trendyTracker.Job.repository;
 
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.Optional;
-
-import org.springframework.stereotype.Repository;
-
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.trendyTracker.Job.domain.Company;
-import com.trendyTracker.Job.domain.QCompany;
 import com.trendyTracker.Job.domain.Company.CompanyCategory;
 import com.trendyTracker.Job.domain.Model.CompanyInfo;
-
+import com.trendyTracker.Job.domain.QCompany;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
 public class CompanyRepositoryImpl implements CompanyRepository {
-    private final EntityManager em;
-    private JPAQueryFactory queryFactory;
 
-    @Override
-    @Transactional
-    public Company registCompany(CompanyInfo companyInfo) {
+  private final EntityManager em;
+  private JPAQueryFactory queryFactory;
+
+  @Override
+  @Transactional
+  public Company registCompany(CompanyInfo companyInfo) {
     /*
      * 'Company' 저장
      */
-        queryFactory = new JPAQueryFactory(em);
-        QCompany qCompany = QCompany.company;
-        Company newCompany = new Company();
+    queryFactory = new JPAQueryFactory(em);
+    QCompany qCompany = QCompany.company;
 
-        var findCompany = queryFactory.select(qCompany)
-                .from(qCompany)
-                .where(qCompany.company_name.eq(companyInfo.companyName()))
-                .fetchOne();
+    var findCompany = queryFactory
+      .select(qCompany)
+      .from(qCompany)
+      .where(qCompany.company_name.eq(companyInfo.companyName()))
+      .fetchOne();
 
-        if (findCompany != null)
-            return findCompany;
+    if (findCompany != null) return findCompany;
 
-        newCompany.addCompany(companyInfo);
-        em.persist(newCompany);
-        return newCompany;
-    }
+    Company newCompany = new Company(companyInfo);
+    em.persist(newCompany);
+    return newCompany;
+  }
 
-    @Override
-    @Transactional
-    public Company updateCategory(String companyName, CompanyCategory category) {
+  @Override
+  @Transactional
+  public Company updateCategory(String companyName, CompanyCategory category) {
     /*
      * 회사 규모 변경
      */
-        queryFactory = new JPAQueryFactory(em);
-        QCompany qCompany = QCompany.company;
+    queryFactory = new JPAQueryFactory(em);
+    QCompany qCompany = QCompany.company;
 
-        Company company = queryFactory.selectFrom(qCompany)
-                                        .where(qCompany.company_name.eq(companyName))
-                                        .fetchFirst();
+    Company company = queryFactory
+      .selectFrom(qCompany)
+      .where(qCompany.company_name.eq(companyName))
+      .fetchFirst();
 
-        company.updateCategory(category);
+    company.updateCategory(category);
 
-        em.persist(company);
-        return company;
-    }
+    em.persist(company);
+    return company;
+  }
 
-    @Override
-    @Transactional
-    public Company updateGroup(String companyName, String group) {
+  @Override
+  @Transactional
+  public Company updateGroup(String companyName, String group) {
     /*
      * 회사 그룹 변경
      */
-        queryFactory = new JPAQueryFactory(em);
-        QCompany qCompany = QCompany.company;
+    queryFactory = new JPAQueryFactory(em);
+    QCompany qCompany = QCompany.company;
 
-        Company company = queryFactory.selectFrom(qCompany)
-                                        .where(qCompany.company_name.eq(companyName))
-                                        .fetchFirst();
-                                        
-        company.updateGroup(group);
-        em.persist(company);
+    Company company = queryFactory
+      .selectFrom(qCompany)
+      .where(qCompany.company_name.eq(companyName))
+      .fetchFirst();
 
-        return company;
-    }
+    company.updateGroup(group);
+    em.persist(company);
 
-    @Override
-    public List<CompanyInfo> getCompanyAll() {
-        queryFactory = new JPAQueryFactory(em);
-        QCompany qCompany = QCompany.company;
+    return company;
+  }
 
-        var result = queryFactory.select(
-                            qCompany.company_group, 
-                            qCompany.company_category, 
-                            qCompany.company_name)
-                        .from(qCompany)
-                        .fetch();
+  @Override
+  public List<CompanyInfo> getCompanyAll() {
+    queryFactory = new JPAQueryFactory(em);
+    QCompany qCompany = QCompany.company;
 
-        List<CompanyInfo> companyInfoList = result.stream()
-        .map(tuple -> new CompanyInfo(
-            tuple.get(qCompany.company_group),
-            tuple.get(qCompany.company_category),
-            tuple.get(qCompany.company_name)
-        ))
-        .collect(Collectors.toList());
+    var result = queryFactory
+      .select(
+        qCompany.company_group,
+        qCompany.company_category,
+        qCompany.company_name
+      )
+      .from(qCompany)
+      .fetch();
 
-        return companyInfoList;
-    }
+    List<CompanyInfo> companyInfoList = result
+      .stream()
+      .map(tuple ->
+        new CompanyInfo(
+          tuple.get(qCompany.company_group),
+          tuple.get(qCompany.company_category),
+          tuple.get(qCompany.company_name)
+        )
+      )
+      .collect(Collectors.toList());
 
-    @Override
-    public List<CompanyInfo> getCompanyGroupList(String companyGroup) {
+    return companyInfoList;
+  }
+
+  @Override
+  public List<CompanyInfo> getCompanyGroupList(String companyGroup) {
     /*
      * 그룹사 조회
      */
-        queryFactory = new JPAQueryFactory(em);
-        QCompany qCompany = QCompany.company;
+    queryFactory = new JPAQueryFactory(em);
+    QCompany qCompany = QCompany.company;
 
-        var result = queryFactory.select(
-                            qCompany.company_group,    
-                            qCompany.company_category,                         
-                            qCompany.company_name)
-                            .from(qCompany)
-                            .where(qCompany.company_group.eq(companyGroup))
-                            .fetch();
+    var result = queryFactory
+      .select(
+        qCompany.company_group,
+        qCompany.company_category,
+        qCompany.company_name
+      )
+      .from(qCompany)
+      .where(qCompany.company_group.eq(companyGroup))
+      .fetch();
 
-        List<CompanyInfo> companyInfoList = result.stream()
-        .map(tuple -> new CompanyInfo(
-            tuple.get(qCompany.company_group),
-            tuple.get(qCompany.company_category),
-            tuple.get(qCompany.company_name)
-        ))
-        .collect(Collectors.toList());
-        
-        return companyInfoList;
-    }
+    List<CompanyInfo> companyInfoList = result
+      .stream()
+      .map(tuple ->
+        new CompanyInfo(
+          tuple.get(qCompany.company_group),
+          tuple.get(qCompany.company_category),
+          tuple.get(qCompany.company_name)
+        )
+      )
+      .collect(Collectors.toList());
 
-    @Override
-    public Optional<Company> findCompanyByName(String company) {
+    return companyInfoList;
+  }
+
+  @Override
+  public Optional<Company> findCompanyByName(String company) {
     /*
      * 회사명으로 회사 검색
      */
-        queryFactory = new JPAQueryFactory(em);
-        QCompany qCompany = QCompany.company;
+    queryFactory = new JPAQueryFactory(em);
+    QCompany qCompany = QCompany.company;
 
-        Company findCompany = queryFactory.selectFrom(qCompany)
-                    .where(qCompany.company_name.eq(company))
-                    .fetchFirst();
+    Company findCompany = queryFactory
+      .selectFrom(qCompany)
+      .where(qCompany.company_name.eq(company))
+      .fetchFirst();
 
-        if(findCompany == null)
-            return Optional.empty();
+    if (findCompany == null) return Optional.empty();
 
-        return Optional.of(findCompany);
-    }
-    
+    return Optional.of(findCompany);
+  }
 }

--- a/src/test/java/com/trendyTracker/service/RecruitServiceTest.java
+++ b/src/test/java/com/trendyTracker/service/RecruitServiceTest.java
@@ -4,257 +4,351 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
-import org.webjars.NotFoundException;
+import com.trendyTracker.Job.domain.Company;
+import com.trendyTracker.Job.domain.Company.CompanyCategory;
+import com.trendyTracker.Job.domain.Model.CompanyInfo;
+import com.trendyTracker.Job.domain.Recruit;
+import com.trendyTracker.Job.service.RecruitService;
+import com.trendyTracker.common.Exception.ExceptionDetail.NoResultException;
+import com.trendyTracker.common.Exception.ExceptionDetail.NotAllowedValueException;
+import com.trendyTracker.util.TechUtils;
+import jakarta.transaction.Transactional;
+import jakarta.validation.ValidationException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-
-import com.trendyTracker.Job.domain.Company;
-import com.trendyTracker.Job.domain.Recruit;
-import com.trendyTracker.Job.domain.Company.CompanyCategory;
-import com.trendyTracker.Job.domain.Model.CompanyInfo;
-import com.trendyTracker.Job.service.RecruitService;
-import com.trendyTracker.common.Exception.ExceptionDetail.NoResultException;
-import com.trendyTracker.common.Exception.ExceptionDetail.NotAllowedValueException;
-import com.trendyTracker.util.TechUtils;
-
-import jakarta.transaction.Transactional;
-import jakarta.validation.ValidationException;
+import org.webjars.NotFoundException;
 
 @SpringBootTest
 @Transactional
 public class RecruitServiceTest {
-    @MockBean
-    private RecruitService recruitService;
 
-    // Test 채용공고 
-    private final String url = "https://www.owl-dev.me/blog/26";
-    private final String company = "owl";
-    private final String jobCategory ="fullstack";
+  @MockBean
+  private RecruitService recruitService;
 
-    @BeforeEach
-    void MockRecruitService() throws NoResultException, IOException, NotAllowedValueException{
-        Company tempCompany1 = new Company();
-        Company tempCompany2 = new Company();
-        Recruit tempRecruit1 = new Recruit();
-        Recruit tempRecruit2 = new Recruit();
+  // Test 채용공고
+  private final String url = "https://www.owl-dev.me/blog/26";
+  private final String company = "owl";
+  private final String jobCategory = "fullstack";
 
-        CompanyInfo companyInfo = new CompanyInfo(company, CompanyCategory.Series_D, "toss");
-        CompanyInfo companyInfo2 = new CompanyInfo(company, CompanyCategory.Series_A, "naver");
-        tempCompany1.addCompany(companyInfo);
-        tempCompany2.addCompany(companyInfo2);
-        tempRecruit1.addRecruit(url, "title", tempCompany1, jobCategory);
-        tempRecruit2.addRecruit(url, "title", tempCompany2, jobCategory);
+  @BeforeEach
+  void MockRecruitService()
+    throws NoResultException, IOException, NotAllowedValueException {
+    CompanyInfo companyInfo = new CompanyInfo(
+      company,
+      CompanyCategory.Series_D,
+      "toss"
+    );
+    CompanyInfo companyInfo2 = new CompanyInfo(
+      company,
+      CompanyCategory.Series_A,
+      "naver"
+    );
+    Company tempCompany1 = new Company(companyInfo);
+    Company tempCompany2 = new Company(companyInfo2);
+    Recruit tempRecruit1 = new Recruit(url, "title", tempCompany1, jobCategory);
+    Recruit tempRecruit2 = new Recruit(url, "title", tempCompany2, jobCategory);
 
-        String[] companies;
-        String[] jobCategories;
-        String[] techs;
-        String[] newTechs;
+    String[] companies;
+    String[] jobCategories;
+    String[] techs;
+    String[] newTechs;
 
-        // regisitJobPostion 
-        when(recruitService.regisitJobPostion(url, "toss", jobCategory))
-        .thenReturn((long)1);
+    // regisitJobPostion
+    when(recruitService.regisitJobPostion(url, "toss", jobCategory))
+      .thenReturn((long) 1);
 
-        // getRecruitList
-        companies = new String[] {"*"};
-        when(recruitService.getRecruitList(companies, null, null, null, null))
-        .thenReturn(new ArrayList<Recruit>() {{add(tempRecruit1); add(tempRecruit2);}});
+    // getRecruitList
+    companies = new String[] { "*" };
+    when(recruitService.getRecruitList(companies, null, null, null, null))
+      .thenReturn(
+        new ArrayList<Recruit>() {
+          {
+            add(tempRecruit1);
+            add(tempRecruit2);
+          }
+        }
+      );
 
-        // getRecruitList
-        companies = new String[] {"toss","naver"};
-        when(recruitService.getRecruitList(companies, null, null, null, null))
-        .thenReturn(new ArrayList<Recruit>() {{add(tempRecruit1); add(tempRecruit2);}});
+    // getRecruitList
+    companies = new String[] { "toss", "naver" };
+    when(recruitService.getRecruitList(companies, null, null, null, null))
+      .thenReturn(
+        new ArrayList<Recruit>() {
+          {
+            add(tempRecruit1);
+            add(tempRecruit2);
+          }
+        }
+      );
 
-        // getRecruitList
-        companies = new String[]{"toss","naver"};
-        jobCategories = new String[]{"backend", "robotics"};
-        when(recruitService.getRecruitList(companies, jobCategories, null, null, null))
-        .thenReturn(new ArrayList<Recruit>() {{add(tempRecruit1); add(tempRecruit2);}});
+    // getRecruitList
+    companies = new String[] { "toss", "naver" };
+    jobCategories = new String[] { "backend", "robotics" };
+    when(
+      recruitService.getRecruitList(companies, jobCategories, null, null, null)
+    )
+      .thenReturn(
+        new ArrayList<Recruit>() {
+          {
+            add(tempRecruit1);
+            add(tempRecruit2);
+          }
+        }
+      );
 
-        // getRecruitList
-        companies = new String[]{"toss","naver"};
-        jobCategories = new String[]{"backend", "robotics"};
-        techs = new String[]{"java"};
-        when(recruitService.getRecruitList(companies, jobCategories, techs, null, null))
-        .thenReturn(new ArrayList<Recruit>() {{add(tempRecruit1); add(tempRecruit2);}});
-        
-        // getRecruitList
-        companies = new String[] {"*"};
-        int pageNo =1;
-        int pageSize=3;
-        when(recruitService.getRecruitList(companies, null, null, pageNo, pageSize))
-        .thenReturn(new ArrayList<Recruit>() {{add(tempRecruit1); add(tempRecruit2);}});
+    // getRecruitList
+    companies = new String[] { "toss", "naver" };
+    jobCategories = new String[] { "backend", "robotics" };
+    techs = new String[] { "java" };
+    when(
+      recruitService.getRecruitList(companies, jobCategories, techs, null, null)
+    )
+      .thenReturn(
+        new ArrayList<Recruit>() {
+          {
+            add(tempRecruit1);
+            add(tempRecruit2);
+          }
+        }
+      );
 
-        // NotFoundException
-        doThrow(new NotFoundException("not found"))
-        .when(recruitService).getRecruitInfo(999);
+    // getRecruitList
+    companies = new String[] { "*" };
+    int pageNo = 1;
+    int pageSize = 3;
+    when(recruitService.getRecruitList(companies, null, null, pageNo, pageSize))
+      .thenReturn(
+        new ArrayList<Recruit>() {
+          {
+            add(tempRecruit1);
+            add(tempRecruit2);
+          }
+        }
+      );
 
-        // updateRecruitTechs
-        newTechs = new String[]{"C#","Python"};  
-        tempRecruit1.updateUrlTechs(TechUtils.makeTechs(newTechs));
-        when(recruitService.updateRecruitTechs(1,newTechs))
-        .thenReturn(tempRecruit1);
+    // NotFoundException
+    doThrow(new NotFoundException("not found"))
+      .when(recruitService)
+      .getRecruitInfo(999);
 
-        // updateJobPosition
-        newTechs = new String[]{"C#","Python"};  
-        when(recruitService.updateJobPosition(url))
-        .thenReturn((long)1);
+    // updateRecruitTechs
+    newTechs = new String[] { "C#", "Python" };
+    tempRecruit1.updateUrlTechs(TechUtils.makeTechs(newTechs));
+    when(recruitService.updateRecruitTechs(1, newTechs))
+      .thenReturn(tempRecruit1);
 
-        // NotAllowedValueException
-        newTechs = new String[]{"C#","Joker"};
-        doThrow(new NotAllowedValueException("not allowed"))
-        .when(recruitService).updateRecruitTechs(1,newTechs);
-    }
+    // updateJobPosition
+    newTechs = new String[] { "C#", "Python" };
+    when(recruitService.updateJobPosition(url)).thenReturn((long) 1);
 
-   
-    @Test
-    @DisplayName("채용 공고 등록")
-    public void regisitJobPostion() throws NoResultException, IOException{
-        // given
-        String company = "toss";     
-        
-        //when 
-        long recruit_id = recruitService.regisitJobPostion(url, company, jobCategory);
+    // NotAllowedValueException
+    newTechs = new String[] { "C#", "Joker" };
+    doThrow(new NotAllowedValueException("not allowed"))
+      .when(recruitService)
+      .updateRecruitTechs(1, newTechs);
+  }
 
-        // then 
-        Assertions.assertThat(recruit_id).isGreaterThan(0);
-    }
+  @Test
+  @DisplayName("채용 공고 등록")
+  public void regisitJobPostion() throws NoResultException, IOException {
+    // given
+    String company = "toss";
 
-    @Test
-    @DisplayName("채용 공고 삭제")
-    public void deleteJobPostion() throws NoResultException, IOException{
-        // given 
-        long recruit_id = 999;
+    //when
+    long recruit_id = recruitService.regisitJobPostion(
+      url,
+      company,
+      jobCategory
+    );
 
-        // when 
-        recruitService.deleteRecruit(recruit_id);
+    // then
+    Assertions.assertThat(recruit_id).isGreaterThan(0);
+  }
 
-        // then 
-        assertThrows(NotFoundException.class, () -> recruitService.getRecruitInfo(recruit_id));
-    }
-    
-    @Test
-    @DisplayName("전체 조회")
-    public void getRecruits() throws ValidationException, NoResultException {
-        // given 
-        String[] companies = {"*"};
+  @Test
+  @DisplayName("채용 공고 삭제")
+  public void deleteJobPostion() throws NoResultException, IOException {
+    // given
+    long recruit_id = 999;
 
-        //when
-        List<Recruit> recruitList = recruitService.getRecruitList(
-            companies, null, null, null, null);
+    // when
+    recruitService.deleteRecruit(recruit_id);
 
-        // then
-        Assertions.assertThat(recruitList.size()).isGreaterThan(0);
-    }
+    // then
+    assertThrows(
+      NotFoundException.class,
+      () -> recruitService.getRecruitInfo(recruit_id)
+    );
+  }
 
-    @Test
-    @DisplayName("회사별 조회")
-    public void getRecruitsByCompanies() throws ValidationException, NoResultException {
-        // given 
-        String[] companies = {"toss","naver"};
+  @Test
+  @DisplayName("전체 조회")
+  public void getRecruits() throws ValidationException, NoResultException {
+    // given
+    String[] companies = { "*" };
 
-        //when
-        List<Recruit> recruitList = recruitService.getRecruitList(
-            companies, null, null, null, null);
+    //when
+    List<Recruit> recruitList = recruitService.getRecruitList(
+      companies,
+      null,
+      null,
+      null,
+      null
+    );
 
-        // then
-        Assertions.assertThat(recruitList.size()).isGreaterThan(0);
-        Assertions.assertThat(recruitList).extracting(x -> x.getCompany().getCompany_name()).contains("toss");
-    }
+    // then
+    Assertions.assertThat(recruitList.size()).isGreaterThan(0);
+  }
 
-    @Test
-    @DisplayName("회사별 + 직군별 조회")
-    public void getRecruitsByCompanies_jobCategory() throws ValidationException, NoResultException {
-        // given 
-        String[] companies = {"toss","naver"};
-        String[] jobCategories = {"backend", "robotics"};
+  @Test
+  @DisplayName("회사별 조회")
+  public void getRecruitsByCompanies()
+    throws ValidationException, NoResultException {
+    // given
+    String[] companies = { "toss", "naver" };
 
-        //when
-        List<Recruit> recruitList = recruitService.getRecruitList(
-            companies, jobCategories, null, null, null);
+    //when
+    List<Recruit> recruitList = recruitService.getRecruitList(
+      companies,
+      null,
+      null,
+      null,
+      null
+    );
 
-        // then
-        Assertions.assertThat(recruitList.size()).isGreaterThan(0);
-        Assertions.assertThat(recruitList).extracting(x -> x.getCompany().getCompany_name()).contains("toss");
-    }
+    // then
+    Assertions.assertThat(recruitList.size()).isGreaterThan(0);
+    Assertions
+      .assertThat(recruitList)
+      .extracting(x -> x.getCompany().getCompany_name())
+      .contains("toss");
+  }
 
-    @Test
-    @DisplayName("회사별 + 직군별 + 기술별 조회")
-    public void getRecruitsByCompanies_jobCategory_techs() throws ValidationException, NoResultException {
-        // given 
-        String[] companies = {"toss","naver"};
-        String[] jobCategories = {"backend", "robotics"};
-        String[] techs ={"java"};
+  @Test
+  @DisplayName("회사별 + 직군별 조회")
+  public void getRecruitsByCompanies_jobCategory()
+    throws ValidationException, NoResultException {
+    // given
+    String[] companies = { "toss", "naver" };
+    String[] jobCategories = { "backend", "robotics" };
 
-        // when
-        List<Recruit> recruitList = recruitService.getRecruitList(
-            companies, jobCategories, techs, null, null);
+    //when
+    List<Recruit> recruitList = recruitService.getRecruitList(
+      companies,
+      jobCategories,
+      null,
+      null,
+      null
+    );
 
-        // then
-        Assertions.assertThat(recruitList.size()).isGreaterThan(0);
-        Assertions.assertThat(recruitList).extracting(x -> x.getCompany().getCompany_name()).contains("toss");
-    }
+    // then
+    Assertions.assertThat(recruitList.size()).isGreaterThan(0);
+    Assertions
+      .assertThat(recruitList)
+      .extracting(x -> x.getCompany().getCompany_name())
+      .contains("toss");
+  }
 
-    @Test
-    @DisplayName("전체 페이지별 조회")
-    public void getRecruitsBypaging() throws ValidationException, NoResultException {
-        // given 
-        String[] companies = {"*"};
-        int pageNo =1;
-        int pageSize=3;
+  @Test
+  @DisplayName("회사별 + 직군별 + 기술별 조회")
+  public void getRecruitsByCompanies_jobCategory_techs()
+    throws ValidationException, NoResultException {
+    // given
+    String[] companies = { "toss", "naver" };
+    String[] jobCategories = { "backend", "robotics" };
+    String[] techs = { "java" };
 
-        // when
-        List<Recruit> recruitList = recruitService.getRecruitList(
-            companies, null, null, pageNo, pageSize);
+    // when
+    List<Recruit> recruitList = recruitService.getRecruitList(
+      companies,
+      jobCategories,
+      techs,
+      null,
+      null
+    );
 
-        // then
-        Assertions.assertThat(recruitList.size()).isGreaterThan(0);
-    }
+    // then
+    Assertions.assertThat(recruitList.size()).isGreaterThan(0);
+    Assertions
+      .assertThat(recruitList)
+      .extracting(x -> x.getCompany().getCompany_name())
+      .contains("toss");
+  }
 
-    @Test
-    @DisplayName("채용 공고 변경")
-    public void changeRecruitTech() throws NoResultException, IOException, NotAllowedValueException{
-        // given
-        long recruit_id = 1;
-        String[] newTechs = {"C#","Python"};
+  @Test
+  @DisplayName("전체 페이지별 조회")
+  public void getRecruitsBypaging()
+    throws ValidationException, NoResultException {
+    // given
+    String[] companies = { "*" };
+    int pageNo = 1;
+    int pageSize = 3;
 
-        // when 
-        Recruit recruit = recruitService.updateRecruitTechs(recruit_id,newTechs);
+    // when
+    List<Recruit> recruitList = recruitService.getRecruitList(
+      companies,
+      null,
+      null,
+      pageNo,
+      pageSize
+    );
 
-        // when, then
-        Assertions.assertThat(recruit.getTechList().contains("C#"));
-        Assertions.assertThat(recruit.getTechList().contains("Python"));
-    }
+    // then
+    Assertions.assertThat(recruitList.size()).isGreaterThan(0);
+  }
 
-    @Test
-    @DisplayName("채용 공고 변경 + 등록되지 않은 기술")
-    public void changeRecruitTechsWithWrongTechs() throws ValidationException, NoResultException, IOException, NotAllowedValueException {
-         // given
-        long recruit_id = 1;
-        String[] newTechs = {"C#","Joker"};
+  @Test
+  @DisplayName("채용 공고 변경")
+  public void changeRecruitTech()
+    throws NoResultException, IOException, NotAllowedValueException {
+    // given
+    long recruit_id = 1;
+    String[] newTechs = { "C#", "Python" };
 
-        // when, then
-        assertThrows(NotAllowedValueException.class, () -> recruitService.updateRecruitTechs(recruit_id, newTechs));
-    }
+    // when
+    Recruit recruit = recruitService.updateRecruitTechs(recruit_id, newTechs);
 
-    @Test
-    @DisplayName("채용공고 재등록")
-    public void updateJobPosition() throws IOException, NoResultException{
-        // given
-        String company = "toss";
-        long recruit_id = recruitService.regisitJobPostion(url, company, jobCategory);
-        // when
-        long result_id = recruitService.updateJobPosition(url);
-        
-        // then
-        Assertions.assertThat(result_id == recruit_id);
-        
-    }
+    // when, then
+    Assertions.assertThat(recruit.getTechList().contains("C#"));
+    Assertions.assertThat(recruit.getTechList().contains("Python"));
+  }
+
+  @Test
+  @DisplayName("채용 공고 변경 + 등록되지 않은 기술")
+  public void changeRecruitTechsWithWrongTechs()
+    throws ValidationException, NoResultException, IOException, NotAllowedValueException {
+    // given
+    long recruit_id = 1;
+    String[] newTechs = { "C#", "Joker" };
+
+    // when, then
+    assertThrows(
+      NotAllowedValueException.class,
+      () -> recruitService.updateRecruitTechs(recruit_id, newTechs)
+    );
+  }
+
+  @Test
+  @DisplayName("채용공고 재등록")
+  public void updateJobPosition() throws IOException, NoResultException {
+    // given
+    String company = "toss";
+    long recruit_id = recruitService.regisitJobPostion(
+      url,
+      company,
+      jobCategory
+    );
+    // when
+    long result_id = recruitService.updateJobPosition(url);
+
+    // then
+    Assertions.assertThat(result_id == recruit_id);
+  }
 }


### PR DESCRIPTION
@Entity 로 만들어둔 클래스에 대해서 생성자를 부여합니다.
기존의 코드로도 기능을 동작하는데 이상은 없지만, 더 좋은 설계를 향해서 리팩토링 진행합니다.



JPA 엔티티 클래스에 기본 생성자가 없는 경우, 다음과 같은 문제들이 발생할 수 있습니다:

**인스턴스 생성 문제:** 
JPA는 엔티티의 인스턴스를 생성할 때 기본 생성자를 사용합니다. 기본 생성자가 없으면 JPA는 엔티티의 인스턴스를 생성할 수 없으며, 이는 런타임 오류를 발생시킬 수 있습니다.

**프록시 생성 문제:** 
JPA는 지연 로딩(Lazy Loading)과 같은 몇몇 기능을 구현하기 위해 엔티티의 프록시 클래스를 생성합니다. 이 프록시 클래스는 기본 생성자를 사용하여 엔티티의 인스턴스를 생성합니다. 기본 생성자가 없으면 프록시 클래스의 생성과 관련된 기능이 제대로 동작하지 않을 수 있습니다.

**유연성 감소:** 
기본 생성자를 제공하면 엔티티의 인스턴스 생성과 초기화를 더 유연하게 할 수 있습니다. 기본 생성자가 없으면 엔티티 인스턴스를 생성할 때 모든 필드를 초기화해야 하므로, 다양한 상황에서의 사용이 제한됩니다.

따라서, JPA 엔티티 클래스는 기본 생성자를 반드시 제공해야 하며, 이는 public 또는 protected 수준의 접근 제한을 가지는 것이 좋습니다. Lombok 같은 라이브러리를 사용하여 간단하게 기본 생성자를 추가할 수 있습니다. 이는 JPA 엔티티의 올바른 동작을 보장하고, 런타임 중 발생할 수 있는 여러 문제들을 예방하는 데 도움이 됩니다.
